### PR TITLE
Check replication lag before failover

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ __pycache__
 tests/integration_test/configs
 configs/ 
 cluster-spec.yaml
+.venv

--- a/mysql_manager/cluster.py
+++ b/mysql_manager/cluster.py
@@ -28,6 +28,9 @@ from mysql_manager.metrics import (
     MASTER_UP_STATUS,
     REPLICA_UP_STATUS,
 )
+from mysql_manager.config import (
+    MAX_REPLICA_DELAY_SECONDS
+)
 
 class ClusterManager: 
     def __init__(self, config_file: str=DEFAULT_CONFIG_PATH):
@@ -120,7 +123,7 @@ class ClusterManager:
         # self._log(str(self.cluster_status))
         self._set_status_metrics()
 
-        if self.repl is not None:  
+        if self.repl is not None: 
             if self.must_replica_join_source(self.repl, self.src): 
                 self.join_replica_to_source(retry=10)
             if (
@@ -139,8 +142,9 @@ class ClusterManager:
                 # TODO: add more checks for replica: if it was not running sql thread for
                 # a long time, if it is behind master for a long time
                 self.src.health_check_failures > self.master_failure_threshold
-                and self.repl.status != MysqlStatus.DOWN.value
+                and self.repl.status != MysqlStatus.DOWN.value and self.repl.get_replication_lag() < MAX_REPLICA_DELAY_SECONDS
             ):
+                
                 self._log("Running failover for cluster")
                 FAILOVER_ATTEMPTS.inc()
                 ## TODO: what if we restart when running this 

--- a/mysql_manager/cluster.py
+++ b/mysql_manager/cluster.py
@@ -142,18 +142,23 @@ class ClusterManager:
                 # TODO: add more checks for replica: if it was not running sql thread for
                 # a long time, if it is behind master for a long time
                 self.src.health_check_failures > self.master_failure_threshold
-                and self.repl.status != MysqlStatus.DOWN.value and self.repl.get_replication_lag() < MAX_REPLICA_DELAY_SECONDS
+                and self.repl.status != MysqlStatus.DOWN.value
             ):
+                replication_lag = self.repl.get_replication_lag()
+                if replication_lag < MAX_REPLICA_DELAY_SECONDS:
+                    self._log("Running failover for cluster")
+                    FAILOVER_ATTEMPTS.inc()
+                    ## TODO: what if we restart when running this 
+                    ## TODO: use etcd txn
+                    self.cluster_data_handler.set_mysql_role(self.src.name, MysqlRoles.REPLICA.value)
+                    self.cluster_data_handler.set_mysql_role(self.repl.name, MysqlRoles.SOURCE.value)
+                    ## TODO: let all relay logs to be applied before resetting replication
+                    self.repl.reset_replication()
+                    self.switch_src_and_repl()
+                else:
+                    self._log(f"Relication lag too high: {replication_lag} skipping failover")
+
                 
-                self._log("Running failover for cluster")
-                FAILOVER_ATTEMPTS.inc()
-                ## TODO: what if we restart when running this 
-                ## TODO: use etcd txn
-                self.cluster_data_handler.set_mysql_role(self.src.name, MysqlRoles.REPLICA.value)
-                self.cluster_data_handler.set_mysql_role(self.repl.name, MysqlRoles.SOURCE.value)
-                ## TODO: let all relay logs to be applied before resetting replication
-                self.repl.reset_replication()
-                self.switch_src_and_repl()
 
         self._log(f"Source is {self.src.host}")
         if self.repl is not None: 

--- a/mysql_manager/cluster.py
+++ b/mysql_manager/cluster.py
@@ -19,6 +19,7 @@ from mysql_manager.cluster_data_handler import ClusterDataHandler
 from mysql_manager.exceptions import (
     MysqlConnectionException,
     MysqlClusterConfigError,
+    FailedToFetchReplicationLag
 )
 from mysql_manager.constants import *
 from mysql_manager.metrics import (
@@ -144,8 +145,13 @@ class ClusterManager:
                 self.src.health_check_failures > self.master_failure_threshold
                 and self.repl.status != MysqlStatus.DOWN.value
             ):
-                replication_lag = self.repl.get_replication_lag()
-                if replication_lag < MAX_REPLICA_DELAY_SECONDS:
+                replication_lag = None
+                try:
+                    replication_lag = self.repl.get_replication_lag()
+                except FailedToFetchReplicationLag as ex:
+                    self._log(f"Skipping failover: {ex}")
+                
+                if replication_lag is not None and replication_lag < MAX_REPLICA_DELAY_SECONDS:
                     self._log("Running failover for cluster")
                     FAILOVER_ATTEMPTS.inc()
                     ## TODO: what if we restart when running this 
@@ -156,7 +162,8 @@ class ClusterManager:
                     self.repl.reset_replication()
                     self.switch_src_and_repl()
                 else:
-                    self._log(f"Relication lag too high: {replication_lag} skipping failover")
+                    if replication_lag is not None:
+                        self._log(f"Relication lag too high: {replication_lag} skipping failover")
 
                 
 

--- a/mysql_manager/config.py
+++ b/mysql_manager/config.py
@@ -1,0 +1,11 @@
+import os
+
+
+def get_int_env_var(key: str,defautl: int) -> int:
+    val = os.getenv(key,str(defautl))
+    try:
+        return int(val)
+    except ValueError:
+        return defautl
+
+MAX_REPLICA_DELAY_SECONDS = get_int_env_var("MAX_REPLICA_DELAY_SECONDS",60)

--- a/mysql_manager/exceptions/exceptions.py
+++ b/mysql_manager/exceptions/exceptions.py
@@ -50,3 +50,7 @@ class FailIntervalLessThanMinimumError(Exception):
         super().__init__(
             f"Variable fail_interval could not be less than {MINIMUM_FAIL_INTERVAL}"
         )
+
+class FailedToFetchReplicationLag(Exception):
+    def __init__(self , reason):
+        super().__init__(f"Failed to fetch replication lag: {reason}")

--- a/mysql_manager/instance.py
+++ b/mysql_manager/instance.py
@@ -8,7 +8,7 @@ from mysql_manager.enums import (
 )
 from mysql_manager.helpers.query_builder import QueryBuilder
 from mysql_manager.dto import MysqlPlugin
-from mysql_manager.exceptions import MysqlConnectionException, MysqlReplicationException, MysqlAddPITREventException, VariableIsNotSetInDatabase
+from mysql_manager.exceptions import MysqlConnectionException, MysqlReplicationException, MysqlAddPITREventException, VariableIsNotSetInDatabase, FailedToFetchReplicationLag
 from mysql_manager.base import BaseServer
 from mysql_manager.constants import DEFAULT_DATABASE
 from mysql_manager.config import (
@@ -361,11 +361,11 @@ select @@global.log_bin, @@global.binlog_format, @@global.gtid_mode, @@global.en
     def get_replication_lag(self) -> int:
         status = self.get_replica_status()
         if status is None:
-            return 0
+            raise FailedToFetchReplicationLag("SHOW REPLICA STATUS returned error")
          
         if status["Seconds_Behind_Source"] is not None:
             return status["Seconds_Behind_Source"]
-        return 0
+        raise FailedToFetchReplicationLag("Seconds_Behind_Source key is not present")
 
     def set_source(self, source):
         if source.is_replica():

--- a/mysql_manager/instance.py
+++ b/mysql_manager/instance.py
@@ -11,6 +11,9 @@ from mysql_manager.dto import MysqlPlugin
 from mysql_manager.exceptions import MysqlConnectionException, MysqlReplicationException, MysqlAddPITREventException, VariableIsNotSetInDatabase
 from mysql_manager.base import BaseServer
 from mysql_manager.constants import DEFAULT_DATABASE
+from mysql_manager.config import (
+    MAX_REPLICA_DELAY_SECONDS
+)
 
 class Mysql(BaseServer):
     def __init__(self, host: str, user: str, password: str, name: str, role: str, port: int=3306) -> None: 
@@ -348,12 +351,21 @@ select @@global.log_bin, @@global.binlog_format, @@global.gtid_mode, @@global.en
             problems.append(MysqlReplicationProblem.IO_ERROR.value)
         if status["Last_SQL_Errno"] != 0 and status["Last_SQL_Error"] != "":
             problems.append(MysqlReplicationProblem.SQL_ERROR.value)
-        if status["Seconds_Behind_Source"] is not None and status["Seconds_Behind_Source"] > 60:
+        if status["Seconds_Behind_Source"] is not None and status["Seconds_Behind_Source"] > MAX_REPLICA_DELAY_SECONDS:
             problems.append(MysqlReplicationProblem.REPLICATION_LAG_HIGH.value)
         if status["Auto_Position"] != 1:
             problems.append(MysqlReplicationProblem.AUTO_POSITION_DISABLED.value)
         
         return problems
+
+    def get_replication_lag(self) -> int:
+        status = self.get_replica_status()
+        if status is None:
+            return 0
+         
+        if status["Seconds_Behind_Source"] is not None:
+            return status["Seconds_Behind_Source"]
+        return 0
 
     def set_source(self, source):
         if source.is_replica():


### PR DESCRIPTION
A new configuration introduced for max replication lag.
If the replica is far behind the primary we don't failover.